### PR TITLE
Fix syntax for creation hosts.ini file

### DIFF
--- a/ansible-docker.sh
+++ b/ansible-docker.sh
@@ -60,7 +60,7 @@ ansible::test::playbook() {
   : "${GROUP?Please define the group your playbook is written for!}"
   pushd "${GITHUB_WORKSPACE}"
 
-  cat <<EOF | hosts.ini
+  cat <<EOF | tee hosts.ini
 [${GROUP}]
 ${HOSTS} ansible_python_interpreter=/usr/bin/python3 ansible_connection=local ansible_host=127.0.0.1"
 EOF


### PR DESCRIPTION
At this moment, every test fails because of missing `tee` with: 
```
/ansible-docker.sh: line 66: hosts.ini: command not found
```