### PR TITLE
Remove bogus closing quote

### DIFF
--- a/ansible-docker.sh
+++ b/ansible-docker.sh
@@ -62,7 +62,7 @@ ansible::test::playbook() {
 
   cat <<EOF | tee hosts.ini
 [${GROUP}]
-${HOSTS} ansible_python_interpreter=/usr/bin/python3 ansible_connection=local ansible_host=127.0.0.1"
+${HOSTS} ansible_python_interpreter=/usr/bin/python3 ansible_connection=local ansible_host=127.0.0.1
 EOF
 
   # execute playbook


### PR DESCRIPTION
Not sure if this was the particular issue (probably yes), but all my tests were passing, while not running any tests:
```
+ ansible-playbook --connection=local --inventory host.ini tests/tests_alternative_file.yml [...] --tags '' --skip-tags '$(( input.skiptags }}'
Warning: : Unable to parse /github/workspace/host.ini as an inventory source
Warning: : No inventory was parsed, only implicit localhost is available
Warning: : provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'

PLAY [all] *********************************************************************
skipping: no hosts matched
```