### PR TITLE
Use existing inventory file

### DIFF
--- a/ansible-docker.sh
+++ b/ansible-docker.sh
@@ -66,7 +66,7 @@ EOF
 
   # execute playbook
   # shellcheck disable=SC2086
-  ansible-playbook --connection=local --inventory host.ini ${TARGETS}
+  ansible-playbook --connection=local --inventory hosts.ini ${TARGETS}
 }
 
 # make sure git is up to date


### PR DESCRIPTION
Current version is causing errors like this and no playbook is executed:
```
+ ansible-playbook --connection=local --inventory host.ini [...] tests/tests_sysconfig.yml
Warning: : Unable to parse /github/workspace/host.ini as an inventory source
Warning: : No inventory was parsed, only implicit localhost is available
Warning: : provided hosts list is empty, only localhost is available. Note that
```